### PR TITLE
Update documentation to reference main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   ht2:
-    github: yourusername/ht2
-    version: ~> 0.1.0
+    github: nomadlabsinc/ht2
+    branch: main
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Update shard installation instructions in README.md to use correct GitHub repository URL
- Change from version-based installation to branch-based installation pointing to `main`

## Test plan
- [ ] Verify the installation instructions are correct by testing with a new Crystal project
- [ ] Confirm the GitHub repository URL is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)