### PR TITLE
Add nghttp2 package to Docker test environment

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     npm \
     parallel \
     coreutils \
-    grep
+    grep \
+    nghttp2
 
 # Install Python packages with HTTP/2 support
 RUN pip3 install --break-system-packages "httpx[http2]" h2


### PR DESCRIPTION
## Summary
- Install nghttp2 package in Dockerfile.test for HTTP/2 client testing
- Enables future use of nghttp client for integration tests  
- Improves test environment compatibility with HTTP/2 ecosystem tools

## Test plan
- [x] All existing tests continue to pass
- [x] Docker test environment builds successfully
- [x] nghttp2 tools are available in test container

🤖 Generated with [Claude Code](https://claude.ai/code)